### PR TITLE
fix: modal icon - table full width

### DIFF
--- a/resources/views/components/modal-relation-manager.blade.php
+++ b/resources/views/components/modal-relation-manager.blade.php
@@ -7,7 +7,7 @@
 
 <div @class([
     "-mx-6 [&_.fi-ta-ctn]:![box-shadow:none]",
-    "-ml-[5.2rem]" => $fixIconPaddingLeft,
+    "-ms-[5.25rem]" => $fixIconPaddingLeft,
     "[&_.fi-ta-header-heading]:hidden" => $shouldHideRelationManagerHeading,
 ])>
     @livewire($relationManager, ['ownerRecord' => $ownerRecord])

--- a/resources/views/components/modal-relation-manager.blade.php
+++ b/resources/views/components/modal-relation-manager.blade.php
@@ -2,10 +2,12 @@
     'ownerRecord',
     'relationManager',
     'shouldHideRelationManagerHeading' => true,
+    'fixIconPaddingLeft',
 ])
 
 <div @class([
     "-mx-6 [&_.fi-ta-ctn]:![box-shadow:none]",
+    "-ml-[5.2rem]" => $fixIconPaddingLeft,
     "[&_.fi-ta-header-heading]:hidden" => $shouldHideRelationManagerHeading,
 ])>
     @livewire($relationManager, ['ownerRecord' => $ownerRecord])

--- a/src/Actions/RelationManagerAction.php
+++ b/src/Actions/RelationManagerAction.php
@@ -52,6 +52,7 @@ class RelationManagerAction extends Action
                     'relationManager' => $this->normalizeRelationManagerClass($this->getRelationManager()),
                     'ownerRecord' => $record,
                     'shouldHideRelationManagerHeading' => $this->shouldHideRelationManagerHeading(),
+                    'fixIconPaddingLeft' => (bool)$this->getModalIcon() && !in_array($this->getModalWidth(), [MaxWidth::ExtraSmall, MaxWidth::Small]),
                 ]);
             })
         ;


### PR DESCRIPTION
When modal has header icon, the table has not the full modal width

**Before:**

MaxWidth::ExtraSmall
![image](https://github.com/user-attachments/assets/d55f7d39-70fa-45b3-949b-8a5e9f608103)

MaxWidth::Medium
![image](https://github.com/user-attachments/assets/94dbe08d-2490-4ced-8068-d6b420e9ec38)


MaxWidth::Full
![image](https://github.com/user-attachments/assets/121e0c9a-02ab-4124-9fb3-3af632675911)


**After:**

MaxWidth::ExtraSmall
![image](https://github.com/user-attachments/assets/f1a6f090-be39-4892-910a-85cd354aa21c)

MaxWidth::Small
![image](https://github.com/user-attachments/assets/9046a8e5-d59e-4b92-9578-a6bdbc482121)

MaxWidth::Medium
![image](https://github.com/user-attachments/assets/fc5d8f35-c487-4844-951a-20421f223b22)

MaxWidth::Full
![image](https://github.com/user-attachments/assets/c864c1fd-9805-4654-90f2-94112c32b0b2)

MaxWidth::Screen
![image](https://github.com/user-attachments/assets/7e106e75-04a0-464a-8591-179f63346ddb)




