### PR TITLE
Add Infolist action

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,13 @@ class LessonsRelationManager extends RelationManager
 ```
 
 And that's it! Now you can use the `RelationManagerAction` anywhere you like to open the relation manager as a modal:
+
 ```php
-use Guava\FilamentModalRelationManagers\Actions\RelationManagerAction;
+use Guava\FilamentModalRelationManagers\Actions\Table\RelationManagerAction;
 
 // for example in a resource table
 
-public CourseResorce extends Resource {
+public CourseResource extends Resource {
 
     // ...
 
@@ -82,6 +83,32 @@ public CourseResorce extends Resource {
                 RelationManagerAction::make('lesson-relation-manager')
                     ->label('View lessons')
                     ->relationManager(LessonRelationManager::make()),
+            ])
+        // ...
+        ;
+    }
+
+    // ...
+}
+```
+
+```php
+use Guava\FilamentModalRelationManagers\Actions\Infolist\RelationManagerAction;
+
+// for example in a resource infolist
+
+public CourseResource extends Resource {
+
+    // ...
+
+    public static function infolist(Infolist $infolist): Infolist
+    {
+        return $infolist
+            ->schema([
+                TextEntry::make('title')
+                    ->suffixAction(RelationManagerAction::make()
+                        ->label('View lessons')
+                        ->relationManager(LessonRelationManager::make()))
             ])
         // ...
         ;

--- a/src/Actions/Infolist/RelationManagerAction.php
+++ b/src/Actions/Infolist/RelationManagerAction.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Guava\FilamentModalRelationManagers\Actions\Infolist;
+
+use Filament\Infolists\Components\Actions\Action;
+use Guava\FilamentModalRelationManagers\Concerns;
+
+class RelationManagerAction extends Action
+{
+    use Concerns\HasRelationManagerAction;
+}

--- a/src/Actions/Table/RelationManagerAction.php
+++ b/src/Actions/Table/RelationManagerAction.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Guava\FilamentModalRelationManagers\Actions\Table;
+
+use Filament\Tables\Actions\Action;
+use Guava\FilamentModalRelationManagers\Concerns;
+
+class RelationManagerAction extends Action
+{
+    use Concerns\HasRelationManagerAction;
+}

--- a/src/Concerns/HasRelationManagerAction.php
+++ b/src/Concerns/HasRelationManagerAction.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Guava\FilamentModalRelationManagers\Actions;
+namespace Guava\FilamentModalRelationManagers\Concerns;
 
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Resources\RelationManagers\RelationManagerConfiguration;
@@ -10,9 +10,9 @@ use Illuminate\Database\Eloquent\Model;
 
 use function view;
 
-class RelationManagerAction extends Action
+trait HasRelationManagerAction
 {
-    protected string | RelationManagerConfiguration $relationManager;
+    protected string|RelationManagerConfiguration $relationManager;
 
     protected bool $hideRelationManagerHeading = true;
 
@@ -21,14 +21,14 @@ class RelationManagerAction extends Action
         return 'modal-relation-manager';
     }
 
-    public function relationManager(RelationManagerConfiguration | string $relationManager): static
+    public function relationManager(RelationManagerConfiguration|string $relationManager): static
     {
         $this->relationManager = $relationManager;
 
         return $this;
     }
 
-    public function getRelationManager(): RelationManagerConfiguration | string
+    public function getRelationManager(): RelationManagerConfiguration|string
     {
         return $this->relationManager;
     }
@@ -55,15 +55,14 @@ class RelationManagerAction extends Action
                     'shouldHideRelationManagerHeading' => $this->shouldHideRelationManagerHeading(),
                     'fixIconPaddingLeft' => (bool) $this->getModalIcon() && ! in_array($this->getModalWidth(), [MaxWidth::ExtraSmall, MaxWidth::Small]),
                 ]);
-            })
-        ;
+            });
     }
 
     /**
      * @param  class-string<RelationManager> | RelationManagerConfiguration  $manager
      * @return class-string<RelationManager>
      */
-    protected function normalizeRelationManagerClass(string | RelationManagerConfiguration $manager): string
+    protected function normalizeRelationManagerClass(string|RelationManagerConfiguration $manager): string
     {
         if ($manager instanceof RelationManagerConfiguration) {
             return $manager->relationManager;


### PR DESCRIPTION
Proposal to open modal with an action in Infolist, eg ```suffixAction()```

And to do this, I move your ```Guava\FilamentModalRelationManagers\Actions\RelationManagerAction.php```  into a Trait, and so by extending this trait to Infolist and Table Action, we can use expected class in Table or Infolist.


For Table
```php
use Guava\FilamentModalRelationManagers\Actions\Table\RelationManagerAction;
```

For Infolist
```php
use Guava\FilamentModalRelationManagers\Actions\Infolist\RelationManagerAction;
```