### PR TITLE
feat: add support for Laravel 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "^8.1",
         "filament/filament": "^5.0",
-        "illuminate/contracts": "^10.0|^11.0|^12.0",
+        "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.14.0"
     },
     "require-dev": {


### PR DESCRIPTION
### Summary

Adds support for Laravel 13 by updating the `illuminate/contracts` version constraint.

### Changes

* Updated `illuminate/contracts` constraint to include `^13.0`

### Testing

* Ran test suite using Pest → all tests passing
* Ran PHPStan analysis → no new issues
* Verified package boots correctly in Testbench

### Notes

This change is backwards-compatible and does not modify existing functionality.
